### PR TITLE
Add port 8043 to JuicePassProxy

### DIFF
--- a/juicepassproxy/config.yaml
+++ b/juicepassproxy/config.yaml
@@ -5,6 +5,7 @@ image: ghcr.io/wozz/ha-addons/juicepassproxy-{arch}
 slug: "juicepassproxy"
 ports:
   "8047/udp": 8047
+  "8043/udp": 8043
   "8042/udp": 8042
 panel_icon: mdi:ev-station
 arch:


### PR DESCRIPTION
For some reason, my JuiceBox uses port 8043.

```
> list
list
! # Type  Info
# 0 FILE  webapp/index.html-1.4.0.24 (1995, 0)
# 1 UDPC  juicenet-udp-prod-usa.enelx.com:8043 (4101)
```